### PR TITLE
Embed into button table properly

### DIFF
--- a/view-button.user.js
+++ b/view-button.user.js
@@ -15,6 +15,7 @@
     'use strict';
 
     let buttonClass = "view_button";
+	let buttonWrapperClass = "view_button_wrapper";
 
     let imageObserver = new MutationObserver(function(mutations) {
         mutations.forEach(function(mutation) {
@@ -33,13 +34,16 @@
                 btn.rel = 'noreferrer';
                 btn.appendChild(span);
 
+				let fullBtn = document.createElement('td');
+				fullBtn.appendChild(btn)
+
                 let menu = container.querySelector('.irc_ab') || container.querySelector('table.irc_but_r tbody tr');
-                let existBtn = menu.querySelector("."+buttonClass);
+                let existBtn = menu.querySelector("."+buttonWrapperClass);
                 if(existBtn) {
                     existBtn.parentNode.removeChild(existBtn);
                 }
 
-                menu.insertBefore(btn, menu.childNodes[1]);
+                menu.insertBefore(fullBtn, menu.childNodes[1]);
             }
         });
     }).observe(document.body, {

--- a/view-button.user.js
+++ b/view-button.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         View Button
 // @namespace    view-button
-// @version      0.1.4
+// @version      0.1.5
 // @description  Returns back "View Image" button for google images
 // @author       0xC0FFEEC0DE
 // @include      /^https://(.*).google.([a-z\.]*)/(imgres|search)(.*)
@@ -14,8 +14,7 @@
 (function() {
     'use strict';
 
-    let buttonClass = "view_button";
-	let buttonWrapperClass = "view_button_wrapper";
+    let buttonWrapperClass = "view_button_wrapper";
 
     let imageObserver = new MutationObserver(function(mutations) {
         mutations.forEach(function(mutation) {
@@ -27,7 +26,7 @@
                 span.textContent = 'View Image';
 
                 let btn = document.createElement('a');
-                btn.className += buttonClass;
+                btn.className += buttonWrapperClass;
                 btn.className += ' NDcgDe dwv50c';
                 btn.target = '_blank';
                 btn.href = mutation.target.src;

--- a/view-button.user.js
+++ b/view-button.user.js
@@ -34,8 +34,8 @@
                 btn.rel = 'noreferrer';
                 btn.appendChild(span);
 
-				let fullBtn = document.createElement('td');
-				fullBtn.appendChild(btn)
+		let fullBtn = document.createElement('td');
+		fullBtn.appendChild(btn)
 
                 let menu = container.querySelector('.irc_ab') || container.querySelector('table.irc_but_r tbody tr');
                 let existBtn = menu.querySelector("."+buttonWrapperClass);


### PR DESCRIPTION
Embedded the button into the table properly so formatting is correct. Notice in the comparisons below that the before has a slightly smaller button (vertically) than the after.

Before:
![](https://pointy.needs-to-s.top/8DfwUKx.png)

After:
![](https://pointy.needs-to-s.top/2f7CW2c.png)