### PR TITLE
Fix @include for Violentmonkey

### DIFF
--- a/view-button.user.js
+++ b/view-button.user.js
@@ -1,10 +1,10 @@
 // ==UserScript==
 // @name         View Button
 // @namespace    view-button
-// @version      0.1.5
+// @version      0.1.6
 // @description  Returns back "View Image" button for google images
 // @author       0xC0FFEEC0DE
-// @include      /^https://(.*).google.([a-z\.]*)/(imgres|search)(.*)
+// @include      /^https://(.*).google.([a-z\.]*)/(imgres|search)(.*)/
 // @downloadURL  https://raw.githubusercontent.com/0xC0FFEEC0DE/make-view-button-back-again/master/view-button.user.js
 // @updateURL    https://raw.githubusercontent.com/0xC0FFEEC0DE/make-view-button-back-again/master/view-button.user.js
 // @grant        none
@@ -31,6 +31,7 @@
                 btn.target = '_blank';
                 btn.href = mutation.target.src;
                 btn.rel = 'noreferrer';
+                btn.style.color = 'white';
                 btn.appendChild(span);
 
 		let fullBtn = document.createElement('td');


### PR DESCRIPTION
As per [Violentmonkey documentation](https://violentmonkey.github.io/api/matching/) and [Greasespot wiki](https://wiki.greasespot.net/Include_and_exclude_rules#Regular_Expressions), the `@include` rule must start **and end** with a slash (/) to be compiled as a regular expression. I hope that'll be ok also for Tampermonkey, but I guess it is.

I also fixed the underline styling of the button rollover, which now is white and consistent with Google's website button to the left :slightly_smiling_face: 